### PR TITLE
Use docker images from GitHub Container Registry rather than Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your `compose.yaml`, include a service like:
 
 ```yaml
   proxy:
-    image: silintl/traefik-https-proxy
+    image: ghcr.io/sil-org/traefik-https-proxy
     ports:
       - "80:80"
       - "443:443"

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,21 +11,21 @@ services:
       - ./local.env
 
   dev1:
-    image: silintl/php8:8.3
+    image: ghcr.io/sil-org/php8:8.3
     ports:
       - "80"
     volumes:
       - ./index.php:/data/frontend/web/index.php
 
   dev2:
-    image: silintl/php8:8.3
+    image: ghcr.io/sil-org/php8:8.3
     ports:
       - "80"
     volumes:
       - ./index.php:/data/frontend/web/index.php
 
   dev3:
-    image: silintl/php8:8.3
+    image: ghcr.io/sil-org/php8:8.3
     ports:
       - "80"
     volumes:


### PR DESCRIPTION
### Fixed
- Use docker images from GitHub Container Registry rather than Docker Hub