### PR TITLE
Fix bugs in default handling and refactor code for less complexity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sil-org/go-devs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1-alpine3.7 as builder
+FROM golang:1-alpine3.22 AS builder
 WORKDIR /go/src/entrypoint
+COPY ./go.mod /go/src/entrypoint
 COPY ./entrypoint.go /go/src/entrypoint/
 RUN go build
 

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,5 +1,6 @@
 FROM golang:1-alpine3.7
 WORKDIR /go/src/entrypoint
+COPY ./go.mod /go/src/entrypoint
 COPY ./entrypoint.go /go/src/entrypoint/
 COPY ./entrypoint_test.go /go/src/entrypoint/
 COPY ./traefik.toml /go/src/entrypoint/

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM golang:1-alpine3.7
+FROM golang:1-alpine3.22
 WORKDIR /go/src/entrypoint
 COPY ./go.mod /go/src/entrypoint
 COPY ./entrypoint.go /go/src/entrypoint/

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -133,6 +133,8 @@ func BuildReplacementsFromEnv() ([]Replacement, error) {
 			}
 		case "SANS":
 			value = `"` + strings.ReplaceAll(value, ",", `", "`) + `"`
+		default:
+			// Do nothing
 		}
 
 		configReplacements = append(configReplacements, Replacement{

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -123,7 +123,6 @@ func BuildReplacementsFromEnv() ([]Replacement, error) {
 			}
 
 			value = envvar.Default
-			continue
 		}
 
 		switch envvar.Name {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -122,6 +122,10 @@ func BuildReplacementsFromEnv() ([]Replacement, error) {
 				return configReplacements, fmt.Errorf("missing required env var: %s. Description: %s", envvar.Name, envvar.Desc)
 			}
 
+			if envvar.Default == "" {
+				continue
+			}
+
 			value = envvar.Default
 		}
 

--- a/entrypoint_test.go
+++ b/entrypoint_test.go
@@ -46,9 +46,8 @@ func TestBuildReplacementsFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	replacementsCount := len(replacements)
-	if replacementsCount != 6 {
-		t.Fatal("Replacements did not have enough entries, only found", replacementsCount, "but expected 6")
+	if want, got := 7, len(replacements); want != got {
+		t.Fatal("Replacements did not have enough entries: found", got, "but expected", want)
 	}
 }
 

--- a/entrypoint_test.go
+++ b/entrypoint_test.go
@@ -16,11 +16,11 @@ example val
 another green	
 `
 	replacements := []Replacement{
-		Replacement{
+		{
 			Key:   "TEST",
 			Value: "val",
 		},
-		Replacement{
+		{
 			Key:   "FIELD",
 			Value: "green",
 		},
@@ -28,8 +28,7 @@ another green
 	results := UpdateConfigContent([]byte(original), replacements)
 
 	if string(results) != expected {
-		t.Error("Results to not match expected. Results:", results)
-		t.FailNow()
+		t.Fatal("Results to not match expected. Results:", results)
 	}
 }
 
@@ -37,30 +36,26 @@ func TestBuildReplacementsFromEnv(t *testing.T) {
 	// Test failure for required env var
 	_, err := BuildReplacementsFromEnv()
 	if err == nil {
-		t.Error("BuildReplacementsFromEnv should have failed because no env vars have been set")
-		t.FailNow()
+		t.Fatal("BuildReplacementsFromEnv should have failed because no env vars have been set")
 	}
 
 	setRequiredEnvVars()
 
 	replacements, err := BuildReplacementsFromEnv()
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	replacementsCount := len(replacements)
 	if replacementsCount != 6 {
-		t.Error("Replacements did not have enough entries, only found", replacementsCount, "but expected 6")
-		t.FailNow()
+		t.Fatal("Replacements did not have enough entries, only found", replacementsCount, "but expected 6")
 	}
 }
 
 func TestReadUpdateWrite(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {
-		t.Error("Unable to get current working directory for TestReadUpdateWrite")
-		t.FailNow()
+		t.Fatal("Unable to get current working directory for TestReadUpdateWrite")
 	}
 	readFile := dir + "/traefik.toml"
 	writeFile := dir + "/traefik_test.toml"
@@ -72,8 +67,7 @@ func TestReadUpdateWrite(t *testing.T) {
 
 	configToml, err := ReadTraefikToml(readFile)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	// Make sure placeholders for env vars exist
@@ -82,8 +76,7 @@ func TestReadUpdateWrite(t *testing.T) {
 		search := regexp.MustCompile(envvar.Name)
 		found := search.Find(configToml)
 		if found == nil {
-			t.Error("Did not find key in configToml template for env var", envvar.Name)
-			t.FailNow()
+			t.Fatal("Did not find key in configToml template for env var", envvar.Name)
 		}
 	}
 
@@ -91,8 +84,7 @@ func TestReadUpdateWrite(t *testing.T) {
 	setRequiredEnvVars()
 	replacements, err := BuildReplacementsFromEnv()
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 	configToml = UpdateConfigContent(configToml, replacements)
 
@@ -102,8 +94,7 @@ func TestReadUpdateWrite(t *testing.T) {
 			search := regexp.MustCompile(envvar.Name)
 			found := search.Find(configToml)
 			if found != nil {
-				t.Error("Uh oh, placeholder for required env var still present after update for env var:", envvar.Name)
-				t.FailNow()
+				t.Fatal("Uh oh, placeholder for required env var still present after update for env var:", envvar.Name)
 			}
 		}
 	}
@@ -111,10 +102,8 @@ func TestReadUpdateWrite(t *testing.T) {
 	// Write out test file for manual reivew
 	err = WriteTraefikToml(writeFile, configToml)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
-
 }
 
 func setRequiredEnvVars() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sil-org/traefik-https-proxy
+
+go 1.18


### PR DESCRIPTION
### Changed
- Refactor BuildReplacementsFromEnv to reduce complexity
- Use t.Fatal for tests instead of Error and FailNow
- Use log.Fatal instead of Print and os.Exit(1)

### Fixed
- Fixed issue where defaults would not correctly be set
- Fixed issue where default LETS_ENCRYPT_CA would not be changed to staging URI