### PR TITLE
upgrade GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/traefik-https-proxy
           tags: |
-            # set latest tag for main
             type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run tests
         run: docker compose -f action-services.yml run test
 
@@ -18,10 +18,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
     
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
             registry: ghcr.io
             username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/traefik-https-proxy
@@ -41,7 +41,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update actions version references to latest available to include support for Node 24.